### PR TITLE
Dead enemies branch

### DIFF
--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.ConstrainedExecution;
 using UnityEngine;
 
 public abstract class ActionClass : SelectClass
@@ -43,18 +44,12 @@ public abstract class ActionClass : SelectClass
     {
         HighlightManager.OnActionClicked(this);
     }
+
     public virtual void OnHit()
     {
         Vector3 diffInLocation = Target.myTransform.position - Origin.myTransform.position;
         Origin.UpdateFacing(diffInLocation, 0);
-
-        float percentageDone = 1; //Testing different powered knockbacks
-        if (Target.Health != 0)
-        {
-            percentageDone = Mathf.Clamp(duplicateCard.actualRoll / (float)Target.Health, 0f, 1f);
-        }
-        this.Target.TakeDamage(duplicateCard.actualRoll);
-        CardComparator.Instance.StartStagger(Origin, Target, percentageDone);
+        this.Target.TakeDamage(Origin, duplicateCard.actualRoll);
     }
 
     public bool IsPlayedByPlayer()
@@ -102,6 +97,7 @@ public abstract class ActionClass : SelectClass
             return null;
         }
     }
+
 
     public override void OnMouseEnter()
     {

--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -44,7 +44,7 @@ public abstract class ActionClass : SelectClass
     {
         HighlightManager.OnActionClicked(this);
     }
-
+    //Called when this card hits the enemy, runs any on hit buffs or effects given.
     public virtual void OnHit()
     {
         Vector3 diffInLocation = Target.myTransform.position - Origin.myTransform.position;

--- a/Assets/Scripts/Abstract Classes/EnemyClass.cs
+++ b/Assets/Scripts/Abstract Classes/EnemyClass.cs
@@ -44,8 +44,9 @@ public abstract class EnemyClass : EntityClass
     public override IEnumerator Die()
     {
         int runDistance = 10;
-        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(runDistance, 0, 0), 0, 0.8f));
+        BattleQueue.BattleQueueInstance.RemoveAllInstancesOfEntity(this);
         CombatManager.Instance.RemoveEnemy(this);
+        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(runDistance, 0, 0), 0, 0.8f));
         isDead = true;
         this.gameObject.SetActive(false);
     }

--- a/Assets/Scripts/Abstract Classes/EnemyClass.cs
+++ b/Assets/Scripts/Abstract Classes/EnemyClass.cs
@@ -41,6 +41,7 @@ public abstract class EnemyClass : EntityClass
      */
     public abstract void AddAttack(List<PlayerClass> players);
 
+    //Removes entity cards and self from BQ and combat manager. Kills itself
     public override IEnumerator Die()
     {
         int runDistance = 10;

--- a/Assets/Scripts/Abstract Classes/EnemyClass.cs
+++ b/Assets/Scripts/Abstract Classes/EnemyClass.cs
@@ -43,8 +43,10 @@ public abstract class EnemyClass : EntityClass
 
     public override IEnumerator Die()
     {
-        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(10, 0, 0), 0, 0.8f));
+        int runDistance = 10;
+        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(runDistance, 0, 0), 0, 0.8f));
         CombatManager.Instance.RemoveEnemy(this);
+        isDead = true;
         this.gameObject.SetActive(false);
     }
 

--- a/Assets/Scripts/Abstract Classes/EnemyClass.cs
+++ b/Assets/Scripts/Abstract Classes/EnemyClass.cs
@@ -25,7 +25,7 @@ public abstract class EnemyClass : EntityClass
     {
         base.Start();
         combatInfo.FaceLeft();
-        CombatManager.Instance.enemies.Add(this);
+        CombatManager.Instance.AddEnemy(this);
     }
 
     /*  Given a list of players, the enemy chooses appropriately a target/targets and adds an attack that it chooses to the bq.
@@ -40,6 +40,13 @@ public abstract class EnemyClass : EntityClass
      *  tweaking difficulty later on.
      */
     public abstract void AddAttack(List<PlayerClass> players);
+
+    public override IEnumerator Die()
+    {
+        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(10, 0, 0), 0, 0.8f));
+        CombatManager.Instance.RemoveEnemy(this);
+        this.gameObject.SetActive(false);
+    }
 
     public override IEnumerator ResetPosition()
     {

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -51,6 +51,10 @@ public abstract class EntityClass : SelectClass
         DeEmphasize();
     }
 
+    /*
+     Purpose: Deals damage to this entity and staggers it back 
+     Requires: This Entity is not dead
+     */
 
     public virtual void TakeDamage(EntityClass source, int damage)
     {
@@ -61,13 +65,13 @@ public abstract class EntityClass : SelectClass
         {
             percentageDone = Mathf.Clamp(damage / (float) Health, 0f, 1f);
         }
-        if (isDead) return;
         StartCoroutine(PlayHitAnimation(source, this, percentageDone));
     }
 
+    //Plays both first the stagger entities then 
+    //Requires: Entities are not dead
     private IEnumerator PlayHitAnimation(EntityClass origin, EntityClass target, float percentageDone)
     {
-        if (isDead) yield break;
         yield return StartCoroutine(StaggerEntities(origin, target, percentageDone));
         if (health <= 0)
         {
@@ -80,6 +84,7 @@ public abstract class EntityClass : SelectClass
     origin: The origin of the damage/attack is coming from
     target: The target being staggered back
     percentageDone: Percentage health done to the target
+    Requires: Entities are not dead
      */
     private IEnumerator StaggerEntities(EntityClass origin, EntityClass target, float percentageDone)
     {
@@ -109,6 +114,8 @@ public abstract class EntityClass : SelectClass
     Modifies: this.myTransform
 
     Purpose: Moves this entity to a given location
+
+    Requires: Entity is not dead
      */
     public IEnumerator MoveToPosition(Vector3 destination, float radius, float duration)
     {
@@ -118,7 +125,6 @@ public abstract class EntityClass : SelectClass
         Vector3 diffInLocation = destination - originalPosition;
 
         if ((Vector2) diffInLocation == Vector2.zero) yield break;
-        if (isDead) yield break;
 
         float distance = Mathf.Sqrt(diffInLocation.x * diffInLocation.x + diffInLocation.y * diffInLocation.y);
         float maxProportionTravelled = (distance - radius) / distance;
@@ -182,6 +188,7 @@ public abstract class EntityClass : SelectClass
      * staggeredPosition is the location we want the enemy to stop at. 
      * 
      * Modifies: this.myTransform.position
+     * Requires: Entity is not dead
      */
     public IEnumerator StaggerBack(Vector3 staggeredPosition)
     {
@@ -190,7 +197,6 @@ public abstract class EntityClass : SelectClass
 
         Vector3 diffInLocation = staggeredPosition - originalPosition;
         if ((Vector2)diffInLocation == Vector2.zero) yield break;
-        if (isDead) yield break;
         UpdateFacing(-diffInLocation, 0);
 
 
@@ -232,9 +238,10 @@ public abstract class EntityClass : SelectClass
     {
         HighlightManager.OnEntityClicked(this);
     }
-
+    //Run this to reset the entity position back to its starting position
     public abstract IEnumerator ResetPosition();
 
+    //Removes entity cards and self from BQ and combat manager. Kills itself
     public abstract IEnumerator Die();
     /*
     // Constructor

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -52,14 +52,52 @@ public abstract class EntityClass : SelectClass
     }
 
 
-    public virtual void TakeDamage(int damage)
+    public virtual void TakeDamage(EntityClass source, int damage)
     {
         health = Mathf.Clamp(health - damage, 0, MAX_HEALTH);
         healthBar.setHealth(health);
+        float percentageDone = 1; //Testing different powered knockbacks
+        if (Health != 0)
+        {
+            percentageDone = Mathf.Clamp(damage / (float) Health, 0f, 1f);
+        }
+        if (isDead) return;
+        StartCoroutine(PlayHitAnimation(source, this, percentageDone));
+    }
+
+    private IEnumerator PlayHitAnimation(EntityClass origin, EntityClass target, float percentageDone)
+    {
+        if (isDead) yield break;
+
+        yield return StartCoroutine(StaggerEntities(origin, target, percentageDone));
         if (health <= 0)
         {
-           StartCoroutine(Die());
+            yield return StartCoroutine(Die());
         }
+    }
+
+    /* 
+    Purpose: Staggers an entity back 
+    origin: The origin of the damage/attack is coming from
+    target: The target being staggered back
+    percentageDone: Percentage health done to the target
+     */
+    private IEnumerator StaggerEntities(EntityClass origin, EntityClass target, float percentageDone)
+    {
+        Vector3 directionVector = target.myTransform.position - origin.myTransform.position;
+
+        Vector3 normalizedDirection = directionVector.normalized;
+        float staggerPower = StaggerPowerCalculation(percentageDone);
+        yield return StartCoroutine(target.StaggerBack(target.myTransform.position + normalizedDirection * staggerPower));
+    }
+
+    //Calculates the power of the stagger based on the percentage health done
+    private float StaggerPowerCalculation(float percentageDone)
+    {
+        float minimumPush = 0.8f;
+        float pushSlope = 1.8f;
+        float percentageUntilMaxPush = 1f / 3f; //Reaches Max push at 33% hp lost
+        return minimumPush + pushSlope * Mathf.Clamp(percentageDone / percentageUntilMaxPush, 0f, 1.5f);
     }
 
     /*
@@ -81,6 +119,7 @@ public abstract class EntityClass : SelectClass
         Vector3 diffInLocation = destination - originalPosition;
 
         if ((Vector2) diffInLocation == Vector2.zero) yield break;
+        if (isDead) yield break;
 
         float distance = Mathf.Sqrt(diffInLocation.x * diffInLocation.x + diffInLocation.y * diffInLocation.y);
         float maxProportionTravelled = (distance - radius) / distance;

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -68,7 +68,6 @@ public abstract class EntityClass : SelectClass
     private IEnumerator PlayHitAnimation(EntityClass origin, EntityClass target, float percentageDone)
     {
         if (isDead) yield break;
-
         yield return StartCoroutine(StaggerEntities(origin, target, percentageDone));
         if (health <= 0)
         {
@@ -201,6 +200,7 @@ public abstract class EntityClass : SelectClass
         }
 
         float duration = animator.GetCurrentAnimatorStateInfo(0).length;
+        if (duration > CardComparator.COMBAT_BUFFER_TIME) duration = CardComparator.COMBAT_BUFFER_TIME - 0.2f; //Ensure that animation doesn't exceed buffer time or bug will happen with death.
 
         while (elapsedTime < duration)
         {

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -13,13 +13,15 @@ public abstract class EntityClass : SelectClass
     public Transform myTransform;
     public CombatInfo combatInfo;
 
+    protected bool isDead = false;
+
     private static readonly float Z_LAYER = -2;
 
     protected Vector3 initalPosition;
     public int Health
     {
         get { return health; }
-        set { health = value; }
+        protected set { health = value; }
     }
 
     protected Dictionary<string, StatusEffect> statusEffects;
@@ -56,7 +58,7 @@ public abstract class EntityClass : SelectClass
         healthBar.setHealth(health);
         if (health <= 0)
         {
-           // Die();
+           StartCoroutine(Die());
         }
     }
 
@@ -193,10 +195,7 @@ public abstract class EntityClass : SelectClass
 
     public abstract IEnumerator ResetPosition();
 
-    public void Die()
-    {
-        Debug.Log("Entity: " + id + " has died");
-    }
+    public abstract IEnumerator Die();
     /*
     // Constructor
     public EntityClass(int health)

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -190,6 +190,7 @@ public abstract class EntityClass : SelectClass
 
         Vector3 diffInLocation = staggeredPosition - originalPosition;
         if ((Vector2)diffInLocation == Vector2.zero) yield break;
+        if (isDead) yield break;
         UpdateFacing(-diffInLocation, 0);
 
 

--- a/Assets/Scripts/Abstract Classes/PlayerClass.cs
+++ b/Assets/Scripts/Abstract Classes/PlayerClass.cs
@@ -48,6 +48,7 @@ public abstract class PlayerClass : EntityClass
     public override IEnumerator Die()
     {
         int runDistance = 10;
+        BattleQueue.BattleQueueInstance.RemoveAllInstancesOfEntity(this);
         CombatManager.Instance.RemovePlayer(this);
         yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(-runDistance, 0, 0), 0, 0.8f));
 

--- a/Assets/Scripts/Abstract Classes/PlayerClass.cs
+++ b/Assets/Scripts/Abstract Classes/PlayerClass.cs
@@ -44,7 +44,7 @@ public abstract class PlayerClass : EntityClass
         yield return StartCoroutine(MoveToPosition(initalPosition, 0f, 0.8f));
         FaceRight();
     }
-
+    //Removes entity cards and self from BQ and combat manager. Kills itself
     public override IEnumerator Die()
     {
         int runDistance = 10;

--- a/Assets/Scripts/Abstract Classes/PlayerClass.cs
+++ b/Assets/Scripts/Abstract Classes/PlayerClass.cs
@@ -47,8 +47,10 @@ public abstract class PlayerClass : EntityClass
 
     public override IEnumerator Die()
     {
-        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(-10, 0, 0), 0, 0.8f));
+        int runDistance = 10;
         CombatManager.Instance.RemovePlayer(this);
+        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(-runDistance, 0, 0), 0, 0.8f));
+
         isDead = true;
         this.gameObject.SetActive(false);
     }

--- a/Assets/Scripts/Abstract Classes/PlayerClass.cs
+++ b/Assets/Scripts/Abstract Classes/PlayerClass.cs
@@ -20,7 +20,7 @@ public abstract class PlayerClass : EntityClass
 
     public override void Start()
     {
-        CombatManager.Instance.players.Add(this);
+        CombatManager.Instance.AddPlayer(this);
         base.Start();
     }
 
@@ -45,13 +45,18 @@ public abstract class PlayerClass : EntityClass
         FaceRight();
     }
 
+    public override IEnumerator Die()
+    {
+        yield return StartCoroutine(MoveToPosition(myTransform.position + new Vector3(-10, 0, 0), 0, 0.8f));
+        CombatManager.Instance.RemovePlayer(this);
+        isDead = true;
+        this.gameObject.SetActive(false);
+    }
+
     public override void FaceRight()
     {
-        
         this.GetComponent<SpriteRenderer>().flipX = false;
         combatInfo.FaceRight();
-        
-        
     }
 
     public override void FaceLeft()

--- a/Assets/Scripts/Abstract Classes/SelectClass.cs
+++ b/Assets/Scripts/Abstract Classes/SelectClass.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public abstract class SelectClass : MonoBehaviour
 {
 
-    protected string myName;
+    public string myName;
     protected Material outliner;
     protected Material ogMaterial;
     protected bool isOutlined = false; // deals with enemy selection

--- a/Assets/Scripts/Entities/Jackie.cs
+++ b/Assets/Scripts/Entities/Jackie.cs
@@ -118,14 +118,4 @@ public class Jackie : PlayerClass
         return null;
     }
 
-
-
-    // Update is called once per frame
-    void Update()
-    {
-        if (Input.GetKeyDown(KeyCode.Space))
-        {
-            TakeDamage(5);
-        }        
-    }
 }

--- a/Assets/Scripts/Entities/WasteFrog.cs
+++ b/Assets/Scripts/Entities/WasteFrog.cs
@@ -32,19 +32,6 @@ public class WasteFrog : EnemyClass
 
     }
 
-    public override void TakeDamage(int damage)
-    {
-        base.TakeDamage(damage);
-
-        //StartCoroutine(StaggerBack(myTransform.position + new Vector3(1.5f, 0, 0)));
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
     /*  Contains: 1x Slap, 1x Flail
      * 
      */

--- a/Assets/Scripts/Enums/GameState.cs
+++ b/Assets/Scripts/Enums/GameState.cs
@@ -6,5 +6,7 @@ public enum GameState
 {
     FIGHTING,
     SELECTION,
+    GAME_WIN,
+    GAME_LOSE,
 
 }

--- a/Assets/Scripts/Managers/BattleQueue.cs
+++ b/Assets/Scripts/Managers/BattleQueue.cs
@@ -197,7 +197,6 @@ public class BattleQueue : MonoBehaviour
                 ActionClass actionClass = array[i];
                 if (actionClass.Origin == entity || actionClass.Target == entity)
                 {
-                    Debug.Log(actionClass.myName + " Has been removed from the BQ");
                     array.RemoveAt(i); //TODO: Should update so that player cards are returned if not used. 
                 }
             }

--- a/Assets/Scripts/Managers/BattleQueue.cs
+++ b/Assets/Scripts/Managers/BattleQueue.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor.PackageManager;
 using UnityEngine;
 
 public class BattleQueue : MonoBehaviour
@@ -58,6 +59,12 @@ public class BattleQueue : MonoBehaviour
         RenderBQ();
     }
 
+    //Remove all cards with (@param entity) as the target and origin
+    public void RemoveAllInstancesOfEntity(EntityClass entity)
+    {
+        actionQueue.RemoveAllInstancesOfEntity(entity);
+    }
+
 
 
 
@@ -102,11 +109,9 @@ public class BattleQueue : MonoBehaviour
     public IEnumerator Dequeue()
     {
         List<ActionClass> array = actionQueue.GetList();
-        bool beganFighting = false;
         if (!(array.Count == 0))
         {
             CombatManager.Instance.GameState = GameState.FIGHTING;
-            beganFighting = true;
         }
         while (!(array.Count == 0))
         {
@@ -116,7 +121,7 @@ public class BattleQueue : MonoBehaviour
             RenderBQ();
             Debug.Log("An item hath been removed from the BQ");
         }
-        if (beganFighting)
+        if (CombatManager.Instance.GameState == GameState.FIGHTING)
         {
             CombatManager.Instance.GameState = GameState.SELECTION;
         }
@@ -184,17 +189,17 @@ public class BattleQueue : MonoBehaviour
 
         }
 
-        // remove methods are redundant??
-        public void Remove(ActionClass card)
+        public void RemoveAllInstancesOfEntity(EntityClass entity)
         {
-            int index = BinarySearch(card.Speed, 0, array.Count - 1, card.Origin);
-
-            if (index < array.Count && array[index] == card)
+            for (int i = array.Count - 1; i >= 0; i--)
             {
-                // Remove the value at the specified index
-                array.RemoveAt(index);
+                ActionClass actionClass = array[i];
+                if (actionClass.Origin == entity || actionClass.Target == entity)
+                {
+                    Debug.Log(actionClass.myName + " Has been removed from the BQ");
+                    array.RemoveAt(i); //Should update so that player cards are returned if not used. 
+                }
             }
-            // else: element not found
         }
 
         private void RemoveLinearSearch(ActionClass card)

--- a/Assets/Scripts/Managers/BattleQueue.cs
+++ b/Assets/Scripts/Managers/BattleQueue.cs
@@ -189,6 +189,7 @@ public class BattleQueue : MonoBehaviour
 
         }
 
+        //Removes all cards in the battle queue that have (@param entity) as the Origin or target.
         public void RemoveAllInstancesOfEntity(EntityClass entity)
         {
             for (int i = array.Count - 1; i >= 0; i--)
@@ -197,7 +198,7 @@ public class BattleQueue : MonoBehaviour
                 if (actionClass.Origin == entity || actionClass.Target == entity)
                 {
                     Debug.Log(actionClass.myName + " Has been removed from the BQ");
-                    array.RemoveAt(i); //Should update so that player cards are returned if not used. 
+                    array.RemoveAt(i); //TODO: Should update so that player cards are returned if not used. 
                 }
             }
         }

--- a/Assets/Scripts/Managers/CardComparator.cs
+++ b/Assets/Scripts/Managers/CardComparator.cs
@@ -9,7 +9,7 @@ using static UnityEngine.UI.Image;
 public class CardComparator : MonoBehaviour
 {
     public static CardComparator Instance { get; private set; }
-
+    public static readonly float COMBAT_BUFFER_TIME = 1f;
     
 
     // Awake is called when the script instance is being loaded
@@ -68,7 +68,9 @@ public class CardComparator : MonoBehaviour
         {
             Debug.LogWarning("You forgot to specify Cardtype");
         }
-        yield return new WaitForSeconds(1);
+
+        
+        yield return new WaitForSeconds(COMBAT_BUFFER_TIME);
         DeEmphasizeClashers(card1.Origin, card1.Target);
     }
 

--- a/Assets/Scripts/Managers/CardComparator.cs
+++ b/Assets/Scripts/Managers/CardComparator.cs
@@ -41,7 +41,7 @@ public class CardComparator : MonoBehaviour
 
         card1.RollDice();
         card2.RollDice();
-        
+        DeactivateInfo(card1, card2);
 
         if (IsAttack(card1) && IsAttack(card2))
         {
@@ -61,12 +61,13 @@ public class CardComparator : MonoBehaviour
         {
             card1.Origin.BlockAnimation(); //Blocked stuff here not implemented properly
             
-            card2.Target.TakeDamage(card2.Damage);
         } else if (card2.CardType == CardType.Defense)
         {
-            card1.Target.TakeDamage(card1.Damage);
+            
+        } else
+        {
+            Debug.LogWarning("You forgot to specify Cardtype");
         }
-        DeactivateInfo(card1, card2);
         yield return new WaitForSeconds(1);
         DeEmphasizeClashers(card1.Origin, card1.Target);
     }
@@ -89,43 +90,6 @@ public class CardComparator : MonoBehaviour
         }
         return cardOneStaggered;
     }
-
-    //Gives ownership of the stagger Entities animation to the card comparator
-    public void StartStagger(EntityClass origin, EntityClass target, float percentageDone)
-    {
-        StartCoroutine(StaggerEntities(origin, target, percentageDone));
-    }
-
-    /* 
-    Purpose: Staggers an entity back 
-    origin: The origin of the damage/attack is coming from
-    target: The target being staggered back
-    percentageDone: Percentage health done to the target
-     */
-    private IEnumerator StaggerEntities(EntityClass origin, EntityClass target, float percentageDone)
-    {
-        Vector3 directionVector = target.myTransform.position - origin.myTransform.position;
-
-        Vector3 normalizedDirection = directionVector.normalized;
-        float staggerPower = StaggerPowerCalculation(percentageDone);
-        yield return StartCoroutine(target.StaggerBack(target.myTransform.position + normalizedDirection * staggerPower));
-    }
-
-    //Calculates the power of the stagger based on the percentage health done
-    private float StaggerPowerCalculation(float percentageDone)
-    {
-        float minimumPush = 0.8f;
-        float pushSlope = 1.8f;
-        float percentageUntilMaxPush = 1f / 3f; //Reaches Max push at 33% hp lost
-        return minimumPush + pushSlope * Mathf.Clamp(percentageDone / percentageUntilMaxPush, 0f, 1.5f);
-    }
-
-    //Transitions the gamestate to selection mode.
-    private void SelectionMode()
-    {
-        CombatManager.Instance.GameState = GameState.SELECTION;
-    }
-
 
     /*
  EntityClass origin: Origin of the action card played

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -99,7 +99,8 @@ public class CombatManager : MonoBehaviour
         if (players.Count > 0)
         {
             players.Remove(player);
-        } else
+        }
+        if (players.Count == 0)
         {
             Debug.LogWarning("All Players are dead, You Lose...");
         }
@@ -115,7 +116,8 @@ public class CombatManager : MonoBehaviour
         if (enemies.Count > 0)
         {
             enemies.Remove(enemy);
-        } else
+        } 
+        if (enemies.Count == 0)
         {
             Debug.LogWarning("All enemies are dead, You Win!");
         }

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -14,9 +14,8 @@ public class CombatManager : MonoBehaviour
     public CinemachineVirtualCamera baseCamera;
     public CinemachineVirtualCamera dynamicCamera;
 
-    // Priority Queue
-    public List<PlayerClass> players;
-    public List<EnemyClass> enemies;
+    private List<PlayerClass> players = new();
+    private List<EnemyClass> enemies = new();
 
     public GameObject handContainer;
     public GameObject startDequeue;
@@ -88,6 +87,38 @@ public class CombatManager : MonoBehaviour
 
         }
 
+    }
+
+    public void AddPlayer(PlayerClass player)
+    {
+        players.Add(player);
+    }
+
+    public void RemovePlayer(PlayerClass player)
+    {
+        if (players.Count > 0)
+        {
+            players.Remove(player);
+        } else
+        {
+            Debug.LogWarning("All Players are dead, You Lose...");
+        }
+    }
+
+    public void AddEnemy(EnemyClass enemy)
+    {
+        enemies.Add(enemy);
+    }
+
+    public void RemoveEnemy(EnemyClass enemy)
+    {
+        if (enemies.Count > 0)
+        {
+            enemies.Remove(enemy);
+        } else
+        {
+            Debug.LogWarning("All enemies are dead, You Win!");
+        }
     }
 
 

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -102,7 +102,7 @@ public class CombatManager : MonoBehaviour
         }
         if (players.Count == 0)
         {
-            Debug.LogWarning("All Players are dead, You Lose...");
+            GameState = GameState.GAME_LOSE;
         }
     }
 
@@ -119,9 +119,24 @@ public class CombatManager : MonoBehaviour
         } 
         if (enemies.Count == 0)
         {
-            Debug.LogWarning("All enemies are dead, You Win!");
+            GameState = GameState.GAME_WIN;
         }
     }
+
+    private void PerformLose()
+    {
+        Debug.LogWarning("All Players are dead, You Lose...");
+        baseCamera.Priority = 1;
+        dynamicCamera.Priority = 0;
+    }
+
+    private void PerformWin()
+    {
+        Debug.LogWarning("All enemies are dead, You Win!");
+        baseCamera.Priority = 1;
+        dynamicCamera.Priority = 0;
+    }
+
 
 
     private void PerformFighting()
@@ -150,6 +165,12 @@ public class CombatManager : MonoBehaviour
                     break;
                 case GameState.FIGHTING:
                     PerformFighting();
+                    break;
+                case GameState.GAME_WIN:
+                    PerformWin();
+                    break;
+                case GameState.GAME_LOSE:
+                    PerformLose();
                     break;
                 default:
                     break;

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -53,19 +53,19 @@ public class CombatManager : MonoBehaviour
     //Usage: Should be called everytime an Entity changes their direction. 
     public void UpdateCameraBounds()
     {
-        if (dynamicCamera.Follow.GetComponent<EntityClass>()?.IsFacingRight() ?? false)
+        if (dynamicCamera.Follow?.GetComponent<EntityClass>()?.IsFacingRight() ?? false)
         {
             var transposer = dynamicCamera.GetCinemachineComponent<CinemachineFramingTransposer>();
             transposer.m_ScreenX = 0.25f;
         }
-        else if (!(dynamicCamera.Follow.GetComponent<EntityClass>()?.IsFacingRight()) ?? false)
+        else if (!(dynamicCamera.Follow?.GetComponent<EntityClass>()?.IsFacingRight()) ?? false)
         {
             var transposer = dynamicCamera.GetCinemachineComponent<CinemachineFramingTransposer>();
             transposer.m_ScreenX = 0.75f;
         }
     }
 
-    
+    //Allows players to start selection again, resets enemies attacks and position
     private void PerformSelection()
     {
         startDequeue.SetActive(true);
@@ -93,29 +93,39 @@ public class CombatManager : MonoBehaviour
     {
         players.Add(player);
     }
-
+    
+    //Purpose: Call this when a player is removed or killed
     public void RemovePlayer(PlayerClass player)
     {
         if (players.Count > 0)
         {
             players.Remove(player);
+            if (dynamicCamera.Follow?.GetComponent<PlayerClass>() == player)
+            {
+                dynamicCamera.Follow = null;
+            }
+            
         }
         if (players.Count == 0)
         {
             GameState = GameState.GAME_LOSE;
         }
     }
-
+    
     public void AddEnemy(EnemyClass enemy)
     {
         enemies.Add(enemy);
     }
-
+    //Purpose: Call this when an enemy is removed or killed
     public void RemoveEnemy(EnemyClass enemy)
     {
         if (enemies.Count > 0)
         {
             enemies.Remove(enemy);
+            if (dynamicCamera.Follow?.GetComponent<EnemyClass>() == enemy)
+            {
+                dynamicCamera.Follow = null;
+            }
         } 
         if (enemies.Count == 0)
         {


### PR DESCRIPTION
Players and Enemies can now die:

Test around to make sure that both players and enemies die properly and not in a scuffed way with the camera being crazy and animations being jagged around.
Confirm that players can win once all enemies are killed and no further action is allowed.
Confirm that Enemies can win once all players are killed and no further action is allowed.

Note that since players and enemies are disabled after they are killed, they will not be able to run Coroutines meaning we should be careful about that.