### PR TITLE
Implemented Redirection.

### DIFF
--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -6,10 +6,22 @@ using TMPro;
 
 public abstract class ActionClass : SelectClass
 {
-    //The following are 'properties' in C# that make quick getters and setters for private fields. ac.Target for access
-    public EntityClass Target { get; set; }
-    private EntityClass origin;
 
+    //The following are 'properties' in C# that make quick getters and setters for private fields. ac.Target for access
+    private EntityClass target;
+    public EntityClass Target
+    {
+        get { return target; }
+        set
+        {
+            Debug.Log("My target is being changed");
+            targetChanged?.Invoke(this);
+            target = value;
+        }
+    }
+    private EntityClass origin;
+    public delegate void ActionClassDelegate(ActionClass target);
+    public event ActionClassDelegate targetChanged;
     public EntityClass Origin
     {
         get { return origin; }

--- a/Assets/Scripts/Managers/BattleQueue.cs
+++ b/Assets/Scripts/Managers/BattleQueue.cs
@@ -105,7 +105,7 @@ public class BattleQueue : MonoBehaviour
     // Removes the card if it is clicked on by the player whilst it is in the Queue. And then reinserts it into the issuing player's hand/deck. 
      public void DeletePlayerAction(ActionClass action)
     {
-        Wrapper w = wrapperArray.RemoveWrapperWithActionClass(action);
+        Wrapper w = wrapperArray.RemoveWrapperWithActionClass(action); // this builds new wrappers bear in mind. 
         ActionClass a = protoQueue.RemoveLinearSearch(action);
 /*        if (w == null)
         {
@@ -115,6 +115,17 @@ public class BattleQueue : MonoBehaviour
         {
             Debug.Log("Check Removal in Array");
         }*/
+        if (w == null || a == null)
+        {
+            throw new Exception("Logic is flawed. This method was called to delete an action that never existed.");
+        }
+        if (w.EnemyAction != null)
+        {
+            if (!wrapperArray.FindAvailablePlayerActionAndRedirect(w)) // if there is still a clash. 
+            {
+                w.EnemyAction.Target = w.ProtoEnemysTarget; 
+            }
+        }
         RenderBQ();
         PlayerClass player = (PlayerClass)action.Origin;
         player.ReaddCard(action);
@@ -415,6 +426,15 @@ public class BattleQueue : MonoBehaviour
                         if (playerAct.Target == curWrapper.EnemyAction.Origin)// CASE 1; 
                         {
                             curWrapper.PlayerAction = playerAct;
+
+                            // The redirection occurs here because this method is invoked only when the player action can be successfully inserted; this code block's conditions are requisites as well.
+                            if (curWrapper.ProtoEnemysTarget == null) // very important since this is the ORIGINAL target. 
+                            {
+                                curWrapper.ProtoEnemysTarget = (PlayerClass)curWrapper.EnemyAction.Target;
+                                curWrapper.EnemyAction.Target = playerAct.Origin;
+                            }
+                            // redirection complete
+
                             curWrapper.Update();
                             SortWrappers();
                             // DisplayWrapperArray();
@@ -561,14 +581,35 @@ public class BattleQueue : MonoBehaviour
             }
         }
 
-
-
-
         public List<Wrapper> GetWrappers()
         {
             return wrappers;
         }
 
+        // REQUIRES: w.EnemyAction != null
+        // note that the new clash has already been formed at this point. 
+        // w is the discarded wrapper.
+        public bool FindAvailablePlayerActionAndRedirect(Wrapper w)
+        {
+            foreach (Wrapper wrapper in wrappers)
+            {
+                if (wrapper.PlayerAction != null && wrapper.PlayerAction.Target == w.EnemyAction!.Origin && w.EnemyAction == wrapper.EnemyAction)
+                {
+
+                    if (w.ProtoEnemysTarget != null)
+                    {
+                        wrapper.ProtoEnemysTarget = w.ProtoEnemysTarget;
+                    }
+                    else if (wrapper.ProtoEnemysTarget == null)
+                    {
+                        wrapper.ProtoEnemysTarget = (PlayerClass)wrapper.EnemyAction.Target;
+                    }
+                    wrapper.EnemyAction.Target = wrapper.PlayerAction.Origin;
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     // Wrapper Element for WrapperArray;
@@ -576,6 +617,10 @@ public class BattleQueue : MonoBehaviour
     {
         public ActionClass? PlayerAction { get; set; }
         public ActionClass? EnemyAction { get; set; }
+
+        // This field is ONLY ever updated if a clash is introduced. It remains null until so. If a clash is inserted, it will retain information of the primary target until the round ends. Knowledge of this field should remain inside BQ.
+        // Cannot see perfect access modifiers so as to obviate incorrect modification. 
+        public PlayerClass? ProtoEnemysTarget { get; set; } 
 
         public int HighestSpeed { get; set; } // used to sort the wrappers 
                                                 // -1 indicates that the wrapper is empty 

--- a/Assets/Scripts/Managers/CombatCardDisplayManager.cs
+++ b/Assets/Scripts/Managers/CombatCardDisplayManager.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEditor.PackageManager;
+﻿using TMPro;
 using UnityEngine;
-using TMPro;
 
 public class CombatCardDisplayManager : MonoBehaviour
 {
@@ -101,21 +97,23 @@ public class CombatCardDisplayManager : MonoBehaviour
     }
 
     // Highlights the target of a
-    private void HighlightTarget(ActionClass a)
+    private void HighlightTarget(ActionClass actionClass)
     {
         if (!targetHighlighted)
         {
-            a.Target.CrossHair();
+            actionClass.Target.CrossHair();
         }
         targetHighlighted = true;
+        actionClass.targetChanged += DeHighlightTarget;
     }
 
     // Deighlights the target of a
-    private void DeHighlightTarget(ActionClass a)
+    private void DeHighlightTarget(ActionClass actionClass)
     {
+        actionClass.targetChanged -= DeHighlightTarget;
         if (targetHighlighted)
         {
-            a.Target.UnCrossHair();
+            actionClass.Target.UnCrossHair();
         }
         targetHighlighted = false;
     }


### PR DESCRIPTION
> There was a crosshair glitch that occurred; couldn't reproduce it.

> once a clash is formed it remains as per specification so re-redirection is not possible (implications for speed). If the original clashing action is removed the re-redirection occurs OSTENSIBLY. Repeat for consistent behavior. Always redirects to original.
> Explication: there are only two characters. If there were three characters, removing the clashing action would cause a reclash to form, however redirection would not necessarily form as redirection is occuring when a player inserts an action AND a clash is formed.
If confused form a convoluted targeting scheme: explanation for new method inside WrapperArray. Solution is new method.

> should disable crosshairs as you hover over player entity.