### PR TITLE
Reworked card selection branch

### DIFF
--- a/Assets/Prefabs/NewCardPrefabs/CardTemplate.prefab
+++ b/Assets/Prefabs/NewCardPrefabs/CardTemplate.prefab
@@ -204,9 +204,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingLayerID: -172551265
+  m_SortingLayer: 3
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 3fea2e94140c08246a0e502ee92d3761, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -288,8 +288,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -172551265
+  m_SortingLayer: 3
   m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: be0a61eae9100ce4ab8f6613bb7da2d3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -499,8 +499,8 @@ Canvas:
   m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingLayerID: -172551265
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &2932779846026145380
 MonoBehaviour:
@@ -880,8 +880,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -172551265
+  m_SortingLayer: 3
   m_SortingOrder: 1
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1152,8 +1152,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -172551265
+  m_SortingLayer: 3
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 39082e00c2d70460993a929910d40e67, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
@@ -1257,9 +1257,9 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingLayerID: -172551265
+  m_SortingLayer: 3
+  m_SortingOrder: 1
   m_Sprite: {fileID: 21300000, guid: 61a3ecbde544e124ba8f329d0e4f6fb2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -192,11 +192,13 @@ public abstract class ActionClass : SelectClass
             return;
         }
         GameObject textContainer = textContainerTransform.gameObject;
+        Canvas textCanvas = textContainer.GetComponent<Canvas>();
         TextMeshProUGUI NameText = textContainer.transform.Find("NameText").gameObject.GetComponent<TextMeshProUGUI>();
         TextMeshProUGUI lowerBoundText = textContainer.transform.Find("LowerBoundText").gameObject.GetComponent<TextMeshProUGUI>();
         TextMeshProUGUI upperBoundText = textContainer.transform.Find("UpperBoundText").gameObject.GetComponent<TextMeshProUGUI>();
         TextMeshProUGUI SpeedText = textContainer.transform.Find("SpeedText").gameObject.GetComponent<TextMeshProUGUI>();
 
+        textCanvas.overrideSorting = true;
         // Set the text first
         NameText.text = titleName;
         lowerBoundText.text = duplicateCard.rollFloor.ToString();

--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -54,6 +54,15 @@ public abstract class ActionClass : SelectClass
         public int rollCeiling;
         public int actualRoll;
     }
+    public enum CardState
+    {
+        NORMAL,
+        HOVER,
+        CANT_PLAY,
+        CLICKED_STATE,
+    }
+
+    private CardState cardState = CardState.NORMAL;
     public int Speed { get; protected set; }
     public string description;
 
@@ -70,13 +79,12 @@ public abstract class ActionClass : SelectClass
 
     protected Vector3 OriginalPosition;
 
-    protected bool EnqueueMoveDown = false;
-
-    #nullable enable
-
+#nullable enable
+    public delegate void CardStateDelegate(CardState cardState);
     public delegate void CardEventDelegate(ActionClass card);
     public static event CardEventDelegate? cardClickedEvent;
     public static event CardEventDelegate? cardHighlightedEvent;
+    public static event CardStateDelegate? CardSelectedEvent;
 
     public virtual void ExecuteActionEffect()
     {
@@ -91,12 +99,6 @@ public abstract class ActionClass : SelectClass
     public virtual void Start()
     {
 
-    }
-
-    public override void OnMouseDown()
-    {
-        HighlightManager.OnActionClicked(this);
-        cardClickedEvent?.Invoke(this);
     }
     //@Author: Anrui
     //Called when this card hits the enemy, runs any on hit buffs or effects given.
@@ -233,28 +235,27 @@ public abstract class ActionClass : SelectClass
         }
 
     }
+    public override void OnMouseDown()
+    {
+        HighlightManager.OnActionClicked(this);
+        cardClickedEvent?.Invoke(this);
+    }
 
+    public void ToggleSelected()
+    {
+        SetCardState(CardState.CLICKED_STATE);
+    }
+
+    public void ToggleUnSelected()
+    {
+        SetCardState(CardState.HOVER);
+    }
 
     public override void OnMouseEnter()
     {
-        if (!isOutlined)
+        if (cardState == CardState.NORMAL)
         {
-            GetComponent<SpriteRenderer>().color = new Color(0.6f, 0.6f, 0.6f, 1);
-
-            // Get the SpriteRenderers of the child objects
-            SpriteRenderer[] childSpriteRenderers = GetComponentsInChildren<SpriteRenderer>();
-
-            // Now we can access each SpriteRenderer
-            foreach (SpriteRenderer spriteRenderer in childSpriteRenderers)
-            {
-                spriteRenderer.color = new Color(0.6f, 0.6f, 0.6f, 1);
-            }
-
-            transform.position += new Vector3((float)0.04, (float)0.4, 0);
-        }
-        else
-        {
-            EnqueueMoveDown = false;
+            SetCardState(CardState.HOVER);
         }
 
         if (description != null)
@@ -266,59 +267,109 @@ public abstract class ActionClass : SelectClass
 
     public override void OnMouseExit()
     {
-        if (!isOutlined)
+        if (cardState == CardState.HOVER)
         {
-            GetComponent<SpriteRenderer>().color = new Color(1f, 1f, 1f, 1);
-
-            SpriteRenderer[] childSpriteRenderers = GetComponentsInChildren<SpriteRenderer>();
-
-            foreach (SpriteRenderer spriteRenderer in childSpriteRenderers)
-            {
-                spriteRenderer.color = new Color(1f, 1f, 1f, 1);
-            }
-
-            transform.position -= new Vector3((float)0.04, (float)0.4, 0);
-        }
-        else
-        {
-            EnqueueMoveDown = true;
+            SetCardState(CardState.NORMAL);
         }
 
         PopUpNotificationManager.Instance.RemoveDescription();
     }
 
-    public override void Highlight()
+    public void SetCanPlay(bool canPlay)
     {
-        isOutlined = true;
-        GetComponent<SpriteRenderer>().color = new Color(0.6f, 0.6f, 0.6f, 1);
-        SpriteRenderer[] childSpriteRenderers = GetComponentsInChildren<SpriteRenderer>();
+        if (canPlay)
+        {
+            SetCardState(CardState.NORMAL);
+        }
+        else
+        {
+            SetCardState(CardState.CANT_PLAY);
+        }
+    } 
 
+    public void ForceNormalState()
+    {
+        if (cardState == CardState.CLICKED_STATE)
+        {
+            SetCardState(CardState.HOVER);
+            SetCardState(CardState.NORMAL);
+        }
+    }
+    private void SetCardState(CardState nextState)
+    {
+        CardState previousState = cardState;
+        
+        //Transition Diagram
+        // CANT_PLAY <-> NORMAL <-> HOVER <-> CLICKED_STATE
+
+        //Bounces all the bad state transitions
+        if ((previousState == CardState.CANT_PLAY && nextState != CardState.NORMAL) ||
+            (previousState == CardState.NORMAL && (nextState != CardState.CANT_PLAY && nextState != CardState.HOVER)) || 
+            (previousState == CardState.HOVER && (nextState != CardState.NORMAL && nextState != CardState.CLICKED_STATE)) ||
+            (previousState == CardState.CLICKED_STATE && (nextState != CardState.HOVER)))
+        {
+            Debug.Log("Bouncing my state where previous: " + previousState + " and current: " + nextState);
+            return;
+        }
+
+        // Determine the color and position changes based on the current and new states
+        Color newColor = Color.white;
+        Vector3 positionChange = Vector3.zero;
+
+        switch (nextState)
+        {
+            case CardState.NORMAL:
+                newColor = Color.white;
+                if (previousState == CardState.HOVER)
+                {
+                    positionChange = new Vector3(-0.04f, -0.4f, 0);
+                }
+                break;
+            case CardState.HOVER:
+                newColor = new Color(0.6f, 0.6f, 0.6f, 1);
+                if (previousState == CardState.NORMAL)
+                {
+                    positionChange = new Vector3(0.04f, 0.4f, 0);
+                }
+                if (previousState == CardState.CLICKED_STATE)
+                {
+                    CardSelectedEvent?.Invoke(CardState.HOVER);
+                }
+                break;
+            case CardState.CANT_PLAY:
+                newColor = new Color(1f, 200f / 255f, 200f / 255f, 1);
+                if (cardState == CardState.HOVER)
+                {
+                    positionChange = new Vector3(-0.04f, -0.4f, 0); //This state cant happen?
+                }
+                break;
+            case CardState.CLICKED_STATE:
+                newColor = new Color(0.5f, 0.5f, 0.5f, 1);
+                if (previousState == CardState.HOVER)
+                {
+                    CardSelectedEvent?.Invoke(CardState.CLICKED_STATE);
+                }
+                break;
+
+        }
+
+        // Apply the new state
+        cardState = nextState;
+
+        // Apply the color and position changes
+        GetComponent<SpriteRenderer>().color = newColor;
+        transform.position += positionChange;
+
+        // Apply the same color change to child SpriteRenderers
+        SpriteRenderer[] childSpriteRenderers = GetComponentsInChildren<SpriteRenderer>();
         foreach (SpriteRenderer spriteRenderer in childSpriteRenderers)
         {
-            spriteRenderer.color = new Color(0.6f, 0.6f, 0.6f, 1);
+            spriteRenderer.color = newColor;
         }
-        transform.rotation = Quaternion.Euler(0, 0, 0);
-        CombatManager.Instance.CrosshairAllEnemies();
     }
 
-    public override void DeHighlight()
-    {
-        isOutlined = false;
-        GetComponent<SpriteRenderer>().color = new Color(1f, 1f, 1f, 1);
-        SpriteRenderer[] childSpriteRenderers = GetComponentsInChildren<SpriteRenderer>();
 
-        foreach (SpriteRenderer spriteRenderer in childSpriteRenderers)
-        {
-            spriteRenderer.color = new Color(1f, 1f, 1f, 1);
-        }
-        transform.rotation = Quaternion.Euler(0, 0, -5);
-        if (EnqueueMoveDown)
-        {
-            transform.position -= new Vector3((float)0.04, (float)0.4, 0);
-            EnqueueMoveDown = false;
-        }
-        CombatManager.Instance.UncrosshairAllEnemies();
-    }
+
 
 
     //Will activate the checkmark on card UI for indication that it is in the player's deck

--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -80,7 +80,7 @@ public abstract class ActionClass : SelectClass
     protected Vector3 OriginalPosition;
 
 #nullable enable
-    public delegate void CardStateDelegate(CardState cardState);
+    public delegate void CardStateDelegate(CardState previousState, CardState currentState);
     public delegate void CardEventDelegate(ActionClass card);
     public static event CardEventDelegate? CardClickedEvent;
     public static event CardEventDelegate? CardHighlightedEvent;
@@ -344,7 +344,6 @@ public abstract class ActionClass : SelectClass
 
         }
 
-        CardStateChange?.Invoke(nextState);
         // Apply the new state
         cardState = nextState;
 
@@ -358,6 +357,7 @@ public abstract class ActionClass : SelectClass
         {
             spriteRenderer.color = newColor;
         }
+        CardStateChange?.Invoke(previousState, nextState);
     }
 
 

--- a/Assets/Scripts/Abstract Classes/ActionClass.cs
+++ b/Assets/Scripts/Abstract Classes/ActionClass.cs
@@ -82,9 +82,9 @@ public abstract class ActionClass : SelectClass
 #nullable enable
     public delegate void CardStateDelegate(CardState cardState);
     public delegate void CardEventDelegate(ActionClass card);
-    public static event CardEventDelegate? cardClickedEvent;
-    public static event CardEventDelegate? cardHighlightedEvent;
-    public static event CardStateDelegate? CardSelectedEvent;
+    public static event CardEventDelegate? CardClickedEvent;
+    public static event CardEventDelegate? CardHighlightedEvent;
+    public static event CardStateDelegate? CardStateChange;
 
     public virtual void ExecuteActionEffect()
     {
@@ -238,7 +238,7 @@ public abstract class ActionClass : SelectClass
     public override void OnMouseDown()
     {
         HighlightManager.OnActionClicked(this);
-        cardClickedEvent?.Invoke(this);
+        CardClickedEvent?.Invoke(this);
     }
 
     public void ToggleSelected()
@@ -262,7 +262,7 @@ public abstract class ActionClass : SelectClass
         {
             PopUpNotificationManager.Instance.DisplayText(description);
         }
-        cardHighlightedEvent?.Invoke(this);
+        CardHighlightedEvent?.Invoke(this);
     }
 
     public override void OnMouseExit()
@@ -308,7 +308,6 @@ public abstract class ActionClass : SelectClass
             (previousState == CardState.HOVER && (nextState != CardState.NORMAL && nextState != CardState.CLICKED_STATE)) ||
             (previousState == CardState.CLICKED_STATE && (nextState != CardState.HOVER)))
         {
-            Debug.Log("Bouncing my state where previous: " + previousState + " and current: " + nextState);
             return;
         }
 
@@ -331,10 +330,6 @@ public abstract class ActionClass : SelectClass
                 {
                     positionChange = new Vector3(0.04f, 0.4f, 0);
                 }
-                if (previousState == CardState.CLICKED_STATE)
-                {
-                    CardSelectedEvent?.Invoke(CardState.HOVER);
-                }
                 break;
             case CardState.CANT_PLAY:
                 newColor = new Color(1f, 200f / 255f, 200f / 255f, 1);
@@ -345,14 +340,11 @@ public abstract class ActionClass : SelectClass
                 break;
             case CardState.CLICKED_STATE:
                 newColor = new Color(0.5f, 0.5f, 0.5f, 1);
-                if (previousState == CardState.HOVER)
-                {
-                    CardSelectedEvent?.Invoke(CardState.CLICKED_STATE);
-                }
                 break;
 
         }
 
+        CardStateChange?.Invoke(nextState);
         // Apply the new state
         cardState = nextState;
 

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -48,6 +48,7 @@ public abstract class EntityClass : SelectClass
 
     public delegate void EntityDelegate(EntityClass player);
     public static event EntityDelegate? OnEntityDeath;
+    public static event EntityDelegate? OnEntityClicked;
 
     public Sprite? icon;
 

--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -335,7 +335,7 @@ public abstract class EntityClass : SelectClass
 
     public override void OnMouseDown()
     {
-        HighlightManager.Instance.OnEntityClicked(this);
+        OnEntityClicked?.Invoke(this);
     }
     //Run this to reset the entity position back to its starting position
     public abstract IEnumerator ResetPosition();

--- a/Assets/Scripts/Abstract Classes/SelectClass.cs
+++ b/Assets/Scripts/Abstract Classes/SelectClass.cs
@@ -55,7 +55,7 @@ public abstract class SelectClass : MonoBehaviour
 
     public abstract void OnMouseDown();
 
-    public bool Toggle()
+    public virtual bool Toggle()
     {
         isOutlined = !isOutlined;
 

--- a/Assets/Scripts/Dialogue/TutorialIntroduction.cs
+++ b/Assets/Scripts/Dialogue/TutorialIntroduction.cs
@@ -178,7 +178,7 @@ public class TutorialIntroduction : DialogueClasses
     {
         EntityClass.OnEntityDeath += FirstDummyDies; //Setup Listener to set state to Game Win
         PlayerClass.playerReshuffleDeck += PlayerLostOneMaxHandSize;
-        StartCoroutine(StartDialogueWithNextEvent(youCanPlayCardsTutorial, () => { ActionClass.cardHighlightedEvent += OnPlayerFirstHighlightCard; }));
+        StartCoroutine(StartDialogueWithNextEvent(youCanPlayCardsTutorial, () => { ActionClass.CardHighlightedEvent += OnPlayerFirstHighlightCard; }));
     }
 
     private void PlayerLostOneMaxHandSize(PlayerClass player)
@@ -198,7 +198,7 @@ public class TutorialIntroduction : DialogueClasses
     //Once hovering over a card, we talk about speed and power
     private void OnPlayerFirstHighlightCard(ActionClass card)
     {
-        ActionClass.cardHighlightedEvent -= OnPlayerFirstHighlightCard;
+        ActionClass.CardHighlightedEvent -= OnPlayerFirstHighlightCard;
         StartCoroutine(StartDialogueWithNextEvent(cardFieldsTutorial, () => { BattleQueue.playerActionInsertedEvent += OnPlayerFirstInsertCard; }));
     }
 

--- a/Assets/Scripts/Managers/BattleQueue.cs
+++ b/Assets/Scripts/Managers/BattleQueue.cs
@@ -73,6 +73,16 @@ public class BattleQueue : MonoBehaviour
         
     }
 
+    public bool CanInsertCard(ActionClass actionClass)
+    {
+        if (!actionClass)
+        {
+            Debug.LogWarning("Asking to insert a null action class");
+            return false;
+        }
+        return protoQueue.CanInsertCard(actionClass);
+    }
+
 
     // FOR ALL ADD METHODS: the Insert() method of SortedArray() is responsible for insertion into the WrapperArray as well. 
 

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -83,7 +83,7 @@ public class CombatManager : MonoBehaviour
     void Start()
     {
         GameState = GameState.GAME_START; //Put game start code in the performGameStart method.
-        ActionClass.CardSelectedEvent += HandleCrosshairEnemies;
+        ActionClass.CardStateChange += HandleCrosshairEnemies;
     }
 
 

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -50,18 +50,6 @@ public class CombatManager : MonoBehaviour
         }
     }
 
-    public void CrosshairAllEnemies() {
-        foreach (EnemyClass enemy in enemies) {
-            enemy.CrossHair();
-        }
-    }
-
-    public void UncrosshairAllEnemies() {
-        foreach (EnemyClass enemy in enemies) {
-            enemy.UnCrossHair();
-        }
-    }
-
     public int FADE_SORTING_ORDER
     {
         get
@@ -77,22 +65,6 @@ public class CombatManager : MonoBehaviour
             return fadeScreen.gameObject.transform.position.z;
         }
     }
-    public static int GetNextSortingLayerID(int currentSortingLayerID)
-    {
-        var layers = SortingLayer.layers;
-        var currentLayerIndex = System.Array.FindIndex(layers, layer => layer.id == currentSortingLayerID);
-
-        // If the current layer is the last one, return the first layer id
-        if (currentLayerIndex == layers.Length - 1)
-        {
-            return layers[0].id;
-        }
-        else
-        {
-            return layers[currentLayerIndex + 1].id;
-        }
-    }
-
 
     // Awake is called when the script instance is being loaded
     void Awake()
@@ -111,6 +83,7 @@ public class CombatManager : MonoBehaviour
     void Start()
     {
         GameState = GameState.GAME_START; //Put game start code in the performGameStart method.
+        ActionClass.CardSelectedEvent += HandleCrosshairEnemies;
     }
 
 
@@ -328,6 +301,33 @@ public class CombatManager : MonoBehaviour
             yield return null;
         }
         fadeActive = false;
+    }
+    private void CrosshairAllEnemies()
+    {
+        foreach (EnemyClass enemy in enemies)
+        {
+            enemy.CrossHair();
+        }
+    }
+
+    private void UncrosshairAllEnemies()
+    {
+        foreach (EnemyClass enemy in enemies)
+        {
+            enemy.UnCrossHair();
+        }
+    }
+
+    private void HandleCrosshairEnemies(ActionClass.CardState cardState)
+    {
+        if (cardState == ActionClass.CardState.CLICKED_STATE)
+        {
+            CrosshairAllEnemies();
+        }
+        else if (cardState == ActionClass.CardState.HOVER)
+        {
+            UncrosshairAllEnemies();
+        }
     }
 
     public bool CanHighlight()

--- a/Assets/Scripts/Managers/CombatManager.cs
+++ b/Assets/Scripts/Managers/CombatManager.cs
@@ -135,7 +135,7 @@ public class CombatManager : MonoBehaviour
 
         if (players.Count > 0)
         {
-            HighlightManager.Instance.OnEntityClicked(players[0]);
+            HighlightManager.Instance.SetActivePlayer(players[0]);
         }
         BattleQueue.BattleQueueInstance.TheBeginning(); //Nasty but necessary for rendering the current implementation of BQ
     }
@@ -318,13 +318,13 @@ public class CombatManager : MonoBehaviour
         }
     }
 
-    private void HandleCrosshairEnemies(ActionClass.CardState cardState)
+    private void HandleCrosshairEnemies(ActionClass.CardState previousState, ActionClass.CardState nextState)
     {
-        if (cardState == ActionClass.CardState.CLICKED_STATE)
+        if (nextState == ActionClass.CardState.CLICKED_STATE && previousState == ActionClass.CardState.HOVER)
         {
             CrosshairAllEnemies();
         }
-        else if (cardState == ActionClass.CardState.HOVER)
+        else if (nextState == ActionClass.CardState.HOVER && previousState == ActionClass.CardState.CLICKED_STATE)
         {
             UncrosshairAllEnemies();
         }

--- a/Assets/Scripts/Managers/HighlightManager.cs
+++ b/Assets/Scripts/Managers/HighlightManager.cs
@@ -28,96 +28,111 @@ public class HighlightManager : MonoBehaviour // later all entity highlighter
     private void Start()
     {
         CombatManager.OnGameStateChanged += ResetSelection;
+        EntityClass.OnEntityClicked += OnEntityClicked;
     }
 
     private void OnDestroy()
     {
         CombatManager.OnGameStateChanged -= ResetSelection;
+        EntityClass.OnEntityClicked -= OnEntityClicked;
     }
+
 
     public void OnEntityClicked(EntityClass clicked)
     {
         if (CombatManager.Instance.GameState != GameState.SELECTION) return;
-        bool isOutlined = false;
 
-/*        Debug.Log(clicked.GetType());
-        Debug.Log(selectedPlayer);*/
-
-        if (clicked is PlayerClass clickedPlayer) //Pattern Matching in C# :)
+        if (clicked is PlayerClass clickedPlayer)
         {
-            if (clickedPlayer != selectedPlayer)
-            {
-                currentHighlightedAction?.DeHighlight();
-                currentHighlightedAction = null;
-                UnRenderHand();
-            }
+            HandlePlayerClick(clickedPlayer);
+        }
+        else if (clicked is EnemyClass clickedEnemy)
+        {
+            HandleEnemyClick(clickedEnemy);
+        }
+    }
+
+    public void SetActivePlayer(PlayerClass forcedPlayer)
+    {
+        if (forcedPlayer != selectedPlayer)
+        {
+            ResetCurrentHighlightedAction();
+        }
+        selectedPlayer = forcedPlayer;
+        RenderHand(forcedPlayer.Hand);
+    }
+    private void HandlePlayerClick(PlayerClass clickedPlayer)
+    {
+        if (clickedPlayer != selectedPlayer)
+        {
+            ResetCurrentHighlightedAction();
             selectedPlayer = clickedPlayer;
             RenderHand(clickedPlayer.Hand);
         }
+    }
+
+    private void ResetCurrentHighlightedAction()
+    {
+        currentHighlightedAction?.ForceNormalState();
+        currentHighlightedAction = null;
+        UnRenderHand();
+    }
+
+    private void HandleEnemyClick(EnemyClass clickedEnemy)
+    {
+        if (selectedPlayer == null)
+        {
+            PopUpNotificationManager.Instance.DisplayWarning(PopupType.SelectPlayerFirst);
+            return;
+        }
+
+        if (currentHighlightedAction == null)
+        {
+            PopUpNotificationManager.Instance.DisplayWarning(PopupType.SelectActionFirst);
+            return;
+        }
+
+        if (currentHighlightedEnemyEntity == null)
+        {
+            currentHighlightedEnemyEntity = clickedEnemy;
+            currentHighlightedEnemyEntity.Highlight();
+        }
+        else if (currentHighlightedEnemyEntity != clickedEnemy)
+        {
+            currentHighlightedEnemyEntity.DeHighlight();
+            clickedEnemy.Highlight();
+            currentHighlightedEnemyEntity = clickedEnemy;
+        } else
+        {
+            currentHighlightedEnemyEntity.DeHighlight();
+        }
+
+        if (currentHighlightedEnemyEntity != null && currentHighlightedAction != null)
+        {
+            ProcessActionOnEnemy();
+        }
+    }
+
+    private void ProcessActionOnEnemy()
+    {
+        currentHighlightedAction!.Target = currentHighlightedEnemyEntity;
+        bool wasAdded = BattleQueue.BattleQueueInstance.AddPlayerAction(currentHighlightedAction);
+
+        currentHighlightedEnemyEntity!.DeHighlight();
+        currentHighlightedAction.DeHighlight();
+
+        if (selectedPlayer != null && wasAdded)
+        {
+            currentHighlightedAction.ForceNormalState();
+            selectedPlayer.HandleUseCard(currentHighlightedAction);
+        }
         else
         {
-            if (selectedPlayer == null && clicked is EnemyClass) // don't need to check for highlighted action
-            {
-                PopUpNotificationManager.Instance.DisplayWarning(PopupType.SelectPlayerFirst);
-                // no call to PQueue.
-            }
-            else if (currentHighlightedAction == null)
-            {
-                PopUpNotificationManager.Instance.DisplayWarning(PopupType.SelectActionFirst);
-                // no call to PQueue. 
-            }
-            else if (currentHighlightedEnemyEntity == null && clicked is EnemyClass)
-            {
-                currentHighlightedEnemyEntity = clicked;
-                currentHighlightedEnemyEntity.Highlight();
-                isOutlined = true;
-                // no call to PQueue.
-            }
-            else if (currentHighlightedEnemyEntity != clicked && clicked is EnemyClass)
-            {
-                currentHighlightedEnemyEntity?.DeHighlight();
-                clicked.Highlight();
-                currentHighlightedEnemyEntity = clicked;
-                isOutlined = true;
-                // no call to PQueue. 
-            }
-            else if (clicked is EnemyClass && currentHighlightedEnemyEntity != null)
-            {
-                isOutlined = currentHighlightedEnemyEntity.Toggle();
-                // no call to PQueue.
-            }
+            PopUpNotificationManager.Instance.DisplayWarning(PopupType.SameSpeed);
         }
 
-        if (currentHighlightedEnemyEntity != null && currentHighlightedAction != null && isOutlined)
-        {
-            if (selectedPlayer == null)
-            {
-                throw new System.Exception("There has been a logical flaw in the preceding conditional set. You should never have currentHighlightedAction without a PlayerSelected.");
-            }
-
-            // note a tricky case here: you select a player, and an action from that player's deck. You select another player.
-            // Now you select an enemy. Who issued the action?; To counter this vide the setting of highlighted action to null at the beginning of the function
-
-            currentHighlightedAction.Target = currentHighlightedEnemyEntity;
-            
-            // currentHighlightedAction.Origin = selectedPlayer;
-            // the preceding line of code is redundant (look at Initalisation of PlayerClass) and incorrect (see above)
-
-            bool wasAdded = BattleQueue.BattleQueueInstance.AddPlayerAction(currentHighlightedAction); 
-
-            currentHighlightedEnemyEntity.DeHighlight();
-            currentHighlightedAction.DeHighlight();
-            if (selectedPlayer != null && wasAdded) // you would NEED a selected player here. look in present code block
-            {
-                currentHighlightedAction.ForceNormalState();
-                selectedPlayer.HandleUseCard(currentHighlightedAction);
-            } else
-            {
-                PopUpNotificationManager.Instance.DisplayWarning(PopupType.SameSpeed);
-            }
-            currentHighlightedEnemyEntity = null;
-            currentHighlightedAction = null;   
-        }
+        currentHighlightedEnemyEntity = null;
+        currentHighlightedAction = null;
     }
 
     public static void OnActionClicked(ActionClass clicked)

--- a/Assets/Scripts/Managers/HighlightManager.cs
+++ b/Assets/Scripts/Managers/HighlightManager.cs
@@ -35,7 +35,7 @@ public class HighlightManager : MonoBehaviour // later all entity highlighter
         CombatManager.OnGameStateChanged -= ResetSelection;
     }
 
-    private void OnEntityClicked(EntityClass clicked)
+    public void OnEntityClicked(EntityClass clicked)
     {
         if (CombatManager.Instance.GameState != GameState.SELECTION) return;
         bool isOutlined = false;


### PR DESCRIPTION
If you have a Speed Conflict, your card will turn red and you cant play it.
Also refactored highlight manager to make the logic less messy. 
Moved Hand rendering into highlight manager
Added new states to the Cards so that more states can exist in the future.

Considering moving the speed text on cards to be above damage because I felt it was annoying when I had cards with duplicate speeds and I kept trying to play cards that had duplicate speeds. But now that the card turns red, that might help remedy things