### PR TITLE
Fixed Repeat Audio Playing on Rapid Skip

### DIFF
--- a/Assets/Scripts/VNScripts/DialogueManager.cs
+++ b/Assets/Scripts/VNScripts/DialogueManager.cs
@@ -54,7 +54,7 @@ public class DialogueManager : MonoBehaviour
 
         sentences = newSentences;
         inDialogue = true;
-        
+
         DisplayNextSentence();
         yield return new WaitUntil(() => !inDialogue);
     }

--- a/Assets/Scripts/VNScripts/DialogueManager.cs
+++ b/Assets/Scripts/VNScripts/DialogueManager.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 public class DialogueManager : MonoBehaviour
 {
     private const string PAGE_FLIP_SOUND_EFFECT = "Page Flip";
-    public static DialogueManager Instance { get; private set; }
+    public static DialogueManager Instance { get; private set; } = null!;
     private DialogueBox activeDialogueBox = null!;
     [SerializeField]
     private DialogueBox picturelessDialogueBoxComponent = null!;


### PR DESCRIPTION
Changed page flip logic to trigger when the right arrow is released/dialogue ends to prevent rapid audio retrigger on holding the arrow down