### PR TITLE
Implement audio preference persistance

### DIFF
--- a/Assets/Scripts/LevelSelect/PauseMenuV2.cs
+++ b/Assets/Scripts/LevelSelect/PauseMenuV2.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Systems.Persistence;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -21,7 +22,7 @@ public class PauseMenuV2 : MonoBehaviour
     public static bool IsPaused;
     public static event Action DidPause;
 
-    public void Awake()
+    public void Start()
     {
         rootElem = rootDocument?.rootVisualElement ?? throw new Exception($"{nameof(rootDocument)} unset");
         dialogue = rootElem.Q<VisualElement>("dialogue");
@@ -51,6 +52,7 @@ public class PauseMenuV2 : MonoBehaviour
     {
         SetState(State.Unpaused);
         Time.timeScale = 1;
+        SaveLoadSystem.Instance.SavePreferences();
     }
 
     private void SetState(State to)
@@ -152,9 +154,11 @@ public class PauseMenuV2 : MonoBehaviour
 
     private void LoadInitialValues()
     {
+        AudioPreferences a = AudioManager.Instance.GetAudioPreferences();
+        
         // TODO: Load these values from saved settings and sync with audio manager.
-        pauseMenuPanel.Q<Slider>("slider-mus").value = 0.2f;
-        pauseMenuPanel.Q<Slider>("slider-sfx").value = 0.2f;
+        pauseMenuPanel.Q<Slider>("slider-mus").value = a.BackgroundMusicVolume;
+        pauseMenuPanel.Q<Slider>("slider-sfx").value = a.SFXVolume;
         pauseMenuPanel.Q<Toggle>("toggle-vfx").value = ScreenShakeHandler.IsScreenShakeEnabled;
     }
 

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -35,6 +35,7 @@ public class AudioManager : PersistentSingleton<AudioManager>, IBind<AudioPrefer
     [SerializeField] private AudioDatabase sceneAudioDatabase;
 #nullable enable
     private SceneAudio sceneAudio = null!;
+    // We need this reference for serialization purposes
     private AudioPreferences audioPreferences = null!;
 
     private void Start() 
@@ -162,21 +163,11 @@ public class AudioManager : PersistentSingleton<AudioManager>, IBind<AudioPrefer
         BackgroundMusicIntroPlayer.mute = !BackgroundMusicIntroPlayer.mute;
         BackgroundMusicPlayer.mute = !BackgroundMusicPlayer.mute;
     }
-
-    public float SFXVolume() 
-    {
-        return SFXSoundsPlayer.volume;
-    }
     
     public void SFXVolume(float volume)
     {
         SFXSoundsPlayer.volume = volume;
         audioPreferences.SFXVolume = volume;
-    }
-
-    public float MusicVolume() 
-    {
-        return BackgroundMusicPlayer.volume;
     }
     
     public void MusicVolume(float volume)
@@ -186,9 +177,10 @@ public class AudioManager : PersistentSingleton<AudioManager>, IBind<AudioPrefer
         audioPreferences.BackgroundMusicVolume = volume;
     }
     
+    public AudioPreferences GetAudioPreferences() { return audioPreferences; }
+    
     void IBind<AudioPreferences>.Bind(AudioPreferences data)
     {
-        Debug.Log($"Binding AudioPreferences from {data}");
         audioPreferences = data;
         MusicVolume(data.BackgroundMusicVolume);
         SFXVolume(data.SFXVolume);

--- a/Assets/Scripts/Managers/GameStateManager.cs
+++ b/Assets/Scripts/Managers/GameStateManager.cs
@@ -15,7 +15,7 @@ public class GameStateManager : PersistentSingleton<GameStateManager>, IBind<Gam
     private GameStateData data;
 
     public GameStateData Data 
-    { 
+    {
         get
         {
             // Data should only be nullable during development where you can open a scene from any place

--- a/Assets/Scripts/Persistance/Concrete Classes/FileDataService.cs
+++ b/Assets/Scripts/Persistance/Concrete Classes/FileDataService.cs
@@ -23,20 +23,20 @@ namespace Systems.Persistence
             return Path.Combine(dataPath, string.Concat(fileName, ".", fileExtension));
         }
 
-        public void Save(GameData data, bool overwrite = true)
+        public void Save<T>(T data, bool overwrite = true) where T: ISaveData
         {
-            string fileLocation = GetPathToFile(data.Name);
+            string fileLocation = GetPathToFile(data.SaveName);
 
             if (!overwrite && File.Exists(fileLocation))
             {
-                throw new IOException($"File '{data.Name}.{fileExtension}' already exists and can't be overwritten.");
+                throw new IOException($"File '{data.SaveName}.{fileExtension}' already exists and can't be overwritten.");
             }
 
             Debug.Log("Saving Content to " + Application.persistentDataPath);
             File.WriteAllText(fileLocation, serializer.Serialize(data));
         }
 
-        public GameData Load(string name)
+        public T Load<T>(string name) where T: ISaveData
         {
             string fileLocation = GetPathToFile(name);
 
@@ -45,7 +45,7 @@ namespace Systems.Persistence
                 throw new IOException($"File '{name}.{fileExtension}' does not exist in this file");
             }
 
-            return serializer.Deserialize<GameData>(File.ReadAllText(fileLocation));
+            return serializer.Deserialize<T>(File.ReadAllText(fileLocation));;
         }
     }
 }

--- a/Assets/Scripts/Persistance/Concrete Classes/SteamCloudDataService.cs
+++ b/Assets/Scripts/Persistance/Concrete Classes/SteamCloudDataService.cs
@@ -13,7 +13,7 @@ namespace Systems.Persistence {
 
         private string GetPath(string name) => name + EXTENSION;
 
-        public void Save(GameData data, bool overwrite = true) {
+        public void Save<T>(T data, bool overwrite = true) where T: ISaveData {
             if (!SteamManager.Initialized) {
                 Debug.LogWarning("[SteamCloudDataService] Steam is not initialized. Cannot save.");
                 return;
@@ -21,7 +21,7 @@ namespace Systems.Persistence {
 #if STEAMWORKS_NET
             string json = serializer.Serialize(data);
             byte[] bytes = System.Text.Encoding.UTF8.GetBytes(json);
-            string path = GetPath(data.Name);
+            string path = GetPath(data.SaveName);
 
             
             bool result = SteamRemoteStorage.FileWrite(path, bytes, bytes.Length);
@@ -30,12 +30,12 @@ namespace Systems.Persistence {
 
         }
 
-        public GameData Load(string name) {
+        public T Load<T>(string name) where T: ISaveData {
             if (!SteamManager.Initialized) {
                 throw new IOException("Steam is not initialized.");
             }
 
-            GameData gamedData = null;
+            T gamedData = default(T);
 #if STEAMWORKS_NET
             string path = GetPath(name);
 
@@ -48,7 +48,7 @@ namespace Systems.Persistence {
 
             int read = SteamRemoteStorage.FileRead(path, buffer, size);
             string json = System.Text.Encoding.UTF8.GetString(buffer, 0, read);
-            gamedData = serializer.Deserialize<GameData>(json);
+            gamedData = serializer.Deserialize<T>(json);
 #endif
             return gamedData;
         }

--- a/Assets/Scripts/Persistance/Interfaces/IDataService.cs
+++ b/Assets/Scripts/Persistance/Interfaces/IDataService.cs
@@ -3,7 +3,7 @@ namespace Systems.Persistence
 {
     public interface IDataService
     {
-        void Save(GameData data, bool overwrite = true);
-        GameData Load(string name);
+        void Save<T>(T data, bool overwrite = true) where T : ISaveData;
+        T Load<T>(string name) where T : ISaveData;
     }
 }

--- a/Assets/Scripts/Persistance/Interfaces/ISaveData.cs
+++ b/Assets/Scripts/Persistance/Interfaces/ISaveData.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using UnityEngine;
+
+namespace Systems.Persistence {
+    public interface ISaveData {
+        public string SaveName { get; }
+    }
+}

--- a/Assets/Scripts/Persistance/Interfaces/ISaveData.cs.meta
+++ b/Assets/Scripts/Persistance/Interfaces/ISaveData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 911debc1ba7a43e2bc5bd9dc179637fe
+timeCreated: 1754023120


### PR DESCRIPTION
Implements #174 by creating a new file called "Wastelanders User Preferences File.json" in the same directory as the user's save file. We currently save the user's:
- Music volume preference
- SFX volume preference

By default, volumes are assigned to 0.7f if no user preference file is found. 

We do not save the user's preference on having either of them muted (where the user can click on the music button to mute that audio source). Let me know if this is something you want. I can also implement saving other user preferences, such as persisting the user's screen shake setting. 
