### PR TITLE
Re-ordered Animations so Staggered has least priority during double animations

### DIFF
--- a/Assets/Scripts/Abstract Classes/EntityClass.cs
+++ b/Assets/Scripts/Abstract Classes/EntityClass.cs
@@ -302,9 +302,9 @@ public abstract class EntityClass : SelectClass
         if ((Vector2)diffInLocation == Vector2.zero) yield break;
         UpdateFacing(-diffInLocation, null);
 
-        if (HasAnimationParameter("IsStaggered"))
+        if (HasAnimationParameter(STAGGERED_ANIMATION_NAME))
         {
-            animator.SetBool("IsStaggered", true);
+            animator.SetBool(STAGGERED_ANIMATION_NAME, true);
         }
 
         float duration = animator.GetCurrentAnimatorStateInfo(0).length;
@@ -317,9 +317,9 @@ public abstract class EntityClass : SelectClass
             yield return null;
         }
 
-        if (HasAnimationParameter("IsStaggered"))
+        if (HasAnimationParameter(STAGGERED_ANIMATION_NAME))
         {
-            animator.SetBool("IsStaggered", false);
+            animator.SetBool(STAGGERED_ANIMATION_NAME, false);
         }
 
     }
@@ -337,9 +337,9 @@ public abstract class EntityClass : SelectClass
 
     public void SetUnstaggered()
     {
-        if (HasAnimationParameter("IsStaggered"))
+        if (HasAnimationParameter(STAGGERED_ANIMATION_NAME))
         {
-            animator.SetBool("IsStaggered", false);
+            animator.SetBool(STAGGERED_ANIMATION_NAME, false);
         }
     }
 

--- a/Assets/Scripts/Cards/EnemyCards/IPlayableEnemyCard.cs
+++ b/Assets/Scripts/Cards/EnemyCards/IPlayableEnemyCard.cs
@@ -20,7 +20,7 @@ public interface IPlayableEnemyCard
 
         if (animatorController == null || animationClip == null)
         {
-            Debug.LogWarning("AnimatorController or AnimationClip is null. AnimatorController must not be null to support foreign animations.");
+            if (entityClass is PlayerClass) Debug.LogWarning("AnimatorController or AnimationClip is null. AnimatorController must not be null to support foreign animations.");
             return;
         }
 

--- a/Assets/Sprites/Animations/BattleIntroAnimations/Background 1.controller
+++ b/Assets/Sprites/Animations/BattleIntroAnimations/Background 1.controller
@@ -227,7 +227,7 @@ AnimatorStateMachine:
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
-  m_EntryPosition: {x: 50, y: 110, z: 0}
+  m_EntryPosition: {x: 30, y: 180, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -3648186391977925025}

--- a/Assets/Sprites/Animations/Frog Animations/WasteFrogPrefab.controller
+++ b/Assets/Sprites/Animations/Frog Animations/WasteFrogPrefab.controller
@@ -90,10 +90,10 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -2188487873925425930}
   - {fileID: 8139081039779495511}
   - {fileID: -219513731567998904}
   - {fileID: -4696886736180364561}
+  - {fileID: -2188487873925425930}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -225,25 +225,25 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsMoving
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsFrogging
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsCharging
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Sprites/Animations/IvesAnimation/Ives Idle Animation/IvesPrefab.controller
+++ b/Assets/Sprites/Animations/IvesAnimation/Ives Idle Animation/IvesPrefab.controller
@@ -839,7 +839,6 @@ AnimatorState:
   m_Transitions:
   - {fileID: -6821011116470666908}
   - {fileID: -3391060451203324533}
-  - {fileID: -3899512485302628899}
   - {fileID: 7223651306556512171}
   - {fileID: -5932854227607793737}
   - {fileID: 5215933675531362612}
@@ -854,6 +853,7 @@ AnimatorState:
   - {fileID: -8795006118988440706}
   - {fileID: -581544928558328479}
   - {fileID: 1211676076804050314}
+  - {fileID: -3899512485302628899}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Sprites/Animations/Jackie Battle Idle Animation/JackiePrefab.controller
+++ b/Assets/Sprites/Animations/Jackie Battle Idle Animation/JackiePrefab.controller
@@ -612,103 +612,103 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsMoving
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsStaggered
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsStaffing
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsMelee
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsAxing
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsPunching
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsBlocking
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsFlinging
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsExcavating
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsCharging
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsPincering
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsFrogging
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsBlessing
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsPrincessing
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsHatchery
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsFragmenting
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -782,7 +782,6 @@ AnimatorState:
   m_Transitions:
   - {fileID: 3699052399845428169}
   - {fileID: 7835268697450291560}
-  - {fileID: 4790040960574915941}
   - {fileID: 7328997591689916232}
   - {fileID: -8490843648687387635}
   - {fileID: 964978968912694145}
@@ -797,6 +796,7 @@ AnimatorState:
   - {fileID: 6488561747969101377}
   - {fileID: -266975323421803552}
   - {fileID: 8607723226072332338}
+  - {fileID: 4790040960574915941}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Sprites/Animations/PrincessFrog/PrincessFrog.controller
+++ b/Assets/Sprites/Animations/PrincessFrog/PrincessFrog.controller
@@ -156,8 +156,8 @@ AnimatorState:
   m_Transitions:
   - {fileID: -1462133148546309731}
   - {fileID: -762676352508134827}
-  - {fileID: 5755637951287276951}
   - {fileID: -3261030356634484530}
+  - {fileID: 5755637951287276951}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -262,25 +262,25 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsMoving
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsPrincessing
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsBlessing
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Sprites/Animations/QueenBeetleAnim/QueenBeetlePrefab.controller
+++ b/Assets/Sprites/Animations/QueenBeetleAnim/QueenBeetlePrefab.controller
@@ -36,9 +36,9 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -4312183391228385655}
   - {fileID: -3383923389662111966}
   - {fileID: -9200375884137352851}
+  - {fileID: -4312183391228385655}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -143,19 +143,19 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsHatchery
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IsFragmenting
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer


### PR DESCRIPTION
When the blocked sprite wins and the enemy takes damage, both the staggered and block animation booleans get triggered.
By simply rearranging the sorting order of which animation takes precedence over the other, we can get our desired effect. Play the blocking animation > Staggered when both are flipped. 

To test this change, I used the following technique:
Set headshot maximum power to 1, bring only the pistol deck into battle. Use headshot on blocking card. Please test against Regular Frogs, Queen Beetle, and Princess Frog. @drew-gnaw @r-k03 