### PR TITLE
default value for speakername

### DIFF
--- a/Assets/Scripts/DialogueScripts/DialogueBox.cs
+++ b/Assets/Scripts/DialogueScripts/DialogueBox.cs
@@ -41,7 +41,11 @@ public class DialogueBox : MonoBehaviour
        
         bodyText.text = string.Empty;
         this.currentLine = line.BodyText;
-        nameText.text = line.SpeakerName;
+        if (line.SpeakerName != "") {
+            nameText.text = line.SpeakerName;
+        } else {
+            nameText.text = "Narrator";
+        }
 
         if (line.broadcastAnEvent) DialogueBoxEvent?.Invoke();
         StartDialogue();

--- a/Assets/Scripts/LevelSelect/LevelSelectManager.cs
+++ b/Assets/Scripts/LevelSelect/LevelSelectManager.cs
@@ -27,15 +27,16 @@ public class LevelSelectManager : MonoBehaviour
         Debug.Log("Unlock Dialogue");
         levelSelectCanvas.interactable = false;
         levelSelectCanvas.blocksRaycasts = false;
+        string tutorialName = "Tutorial";
         yield return new WaitForSeconds(2f);
         yield return StartCoroutine(DialogueManager
             .Instance
             .StartDialogue(new List<DialogueText>
         {
-            new DialogueText("Welcome to the level select screen!", "", null),
-            new DialogueText("You can select a level to play by clicking on the buttons below.", "", null),
-            new DialogueText("Some levels may be locked until you complete previous levels.", "", null),
-            new DialogueText("Good luck and have fun!", "", null),
+            new DialogueText("Welcome to the level select screen!", tutorialName, null),
+            new DialogueText("You can select a level to play by clicking on the buttons below.", tutorialName, null),
+            new DialogueText("Some levels may be locked until you complete previous levels.", tutorialName, null),
+            new DialogueText("Good luck and have fun!", tutorialName, null),
         }));
         princessFrogFightButton.Unlock(animate: true);
         levelSelectCanvas.interactable = true;


### PR DESCRIPTION
Updated speaker name to show "Narrator" when no speaker is declared.

DialogueBox.cs checks for a name when setting nameText and uses "Narrator" if it is empty.

Dialogue lines in LevelSelectManager.cs have also been updated to use the name "Tutorial".